### PR TITLE
Fix filtering in Safari

### DIFF
--- a/src/Table/CSVTable.jsx
+++ b/src/Table/CSVTable.jsx
@@ -144,7 +144,7 @@ const CSVTable = ({dateStr}) => {
             return;
         } 
 
-        const anyCatParams = searchParams.keys().some(key => Object.keys(categories).includes(key));
+        const anyCatParams = Array.from(searchParams.keys()).some(key => Object.keys(categories).includes(key));
 
         // Parse URL parameters after categories are set
         const updatedCategories = Object.keys(categories).reduce((acc, category) => {


### PR DESCRIPTION
Safari doesn't support Iterator.prototype.some yet so crashes on this line. Tested that converting to array fixes it. https://caniuse.com/mdn-javascript_builtins_iterator_some