### PR TITLE
remove superfluous #/ at the end of link.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,9 @@ import App from './App';
 import Blog from './Blog';
 import reportWebVitals from './reportWebVitals';
 
+if (window.location.hash.startsWith('#/')) {
+    window.location.replace(window.location.toString().replace('#/', ''));
+}
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
Ran into a similar issue where I work with the URL of the page has a superfluous #/ at the end of it. This change should remove that before the page is rendered.