### PR TITLE
modelLinks cleanup: Gemini 3.1 Pro asterisk + Fable 5 note

### DIFF
--- a/src/Table/modelLinks.js
+++ b/src/Table/modelLinks.js
@@ -503,7 +503,7 @@ export const modelLinks = {
         displayName: "Claude Fable 5 Thinking xHigh Effort",
         version: "2026-06-09",
         reasoner: true,
-        note: "*refusals fall back to Opus 4.8 (server-side)",
+        note: "*refusals fall back to Opus 4.8",
         variants: [
             { rawName: "claude-fable-5-high-effort", displayName: "Claude Fable 5 Thinking High Effort" }
         ]

--- a/src/Table/modelLinks.js
+++ b/src/Table/modelLinks.js
@@ -399,7 +399,7 @@ export const modelLinks = {
             { rawName: "gemini-3.5-flash-high", displayName: "Gemini 3.5 Flash High" }
         ]
     },
-    "gemini-3.1-pro-preview-high": {url: "https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview/", organization: "Google", displayName: "Gemini 3.1 Pro Preview High*", note: "*5th rank in unseen questions across all categories", reasoner: true, highUnseenBias: true},
+    "gemini-3.1-pro-preview-high": {url: "https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview/", organization: "Google", displayName: "Gemini 3.1 Pro Preview High", reasoner: true},
     "gemini-3.1-flash-lite-preview-high": {url: "https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite-preview", organization: "Google", displayName: "Gemini 3.1 Flash Lite Preview High", reasoner: true},
     "gpt-5.3-instant": {url: "https://openai.com/index/gpt-5-3-instant/", organization: "OpenAI", displayName: "GPT-5.3 Instant", version: "2026-02-24"},
     "gpt-5.3-codex": {


### PR DESCRIPTION
Two small `src/Table/modelLinks.js` note cleanups:

**1. `gemini-3.1-pro-preview-high`** — remove the high-unseen-bias caveat asterisk (no longer applies; rank has come down):
- displayName `"Gemini 3.1 Pro Preview High*"` → `"Gemini 3.1 Pro Preview High"`
- removed `note: "*5th rank in unseen questions across all categories"`
- removed the now-orphaned `highUnseenBias: true` flag (also controlled the "high unseen bias" filter toggle)

**2. `claude-fable-5-xhigh-effort`** — simplify the note:
- `"*refusals fall back to Opus 4.8 (server-side)"` → `"*refusals fall back to Opus 4.8"`

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)